### PR TITLE
touchup readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 ![github workflow status](https://github.com/avaya-dux/neo-library-react/actions/workflows/run-yarn.yml/badge.svg)
 [![npm version](https://badge.fury.io/js/@avaya%2Fneo-react.svg)](https://badge.fury.io/js/@avaya%2Fneo-react)
 
-![Coverage lines](./badges/badge-lines.svg)
-![Coverage functions](./badges/badge-functions.svg)
-![Coverage branches](./badges/badge-branches.svg)
-![Coverage statements](./badges/badge-statements.svg)
+![Coverage lines](https://github.com/avaya-dux/neo-library-react/blob/main/badges/badge-lines.svg)
+![Coverage functions](https://github.com/avaya-dux/neo-library-react/blob/main/badges/badge-functions.svg)
+![Coverage branches](https://github.com/avaya-dux/neo-library-react/blob/main/badges/badge-branches.svg)
+![Coverage statements](https://github.com/avaya-dux/neo-library-react/blob/main/badges/badge-statements.svg)
 
 # Neo React Component Library
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "source": "src/index.ts",
   "files": [
     "dist",
-    "badges",
     "README.md",
     "LICENSE.md",
     "LICENSE-3rd-party.html"

--- a/readmes/how-to-dev.md
+++ b/readmes/how-to-dev.md
@@ -4,6 +4,8 @@
 
 > For unit testing we use [jest](https://jestjs.io/), for integration testing we use [Cypress](https://www.cypress.io/how-it-works), for linting we use [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/).
 
+> You can see an overview of [the libraries structure here](https://app.codesee.io/maps/public/188812a0-d098-11ec-bea5-0157c94ef4f8). Generated via [CodeSee](https://www.codesee.io/).
+
 ## first steps
 
 - use [NodeJS LTS](https://nodejs.org/) (preferably via nvm, [mac nvm](https://tecadmin.net/install-nvm-macos-with-homebrew/) | [windows nvm](https://github.com/coreybutler/nvm-windows#node-version-manager-nvm-for-windows))


### PR DESCRIPTION
add link to library structure tree (codesee) ([how cool is this!?](https://app.codesee.io/maps/public/188812a0-d098-11ec-bea5-0157c94ef4f8))
make links to badge image static
update package script to not include badge images (as they're static and publicly available now that this is a public repo)