### PR TITLE
Neo 735: Reving version for next release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaya/neo-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "This is the React version of the shared library called 'NEO' buit by Avaya",
   "author": "joe-s-avaya",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/src/components/LeftNavigation/index.ts
+++ b/src/components/LeftNavigation/index.ts
@@ -2,3 +2,4 @@ export * from "./TopLinkItem";
 export * from "./NavCategory";
 export * from "./LinkItem";
 export * from "./LeftNavigationTypes";
+export * from "./LeftNavigation";


### PR DESCRIPTION
Made LeftNavigation component public so this requires a new version of Neo.