### PR TITLE
add GitHub issue and PR templates

### DIFF
--- a/docs/issue_template.yml
+++ b/docs/issue_template.yml
@@ -16,7 +16,7 @@ body:
     id: neo-version
     attributes:
       label: What version of `Neo` are you using?
-      placeholder: 0.0.0
+      placeholder: 3.55.1
     validations:
       required: true
   - type: input
@@ -38,6 +38,13 @@ body:
     attributes:
       label: What operating system are you using?
       placeholder: Mac, Windows, Linux
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: What browser and version are you using?
+      placeholder: Chrome 103.0.5060.53
     validations:
       required: true
   - type: textarea

--- a/docs/issue_template.yml
+++ b/docs/issue_template.yml
@@ -1,0 +1,63 @@
+name: "\U0001F41B Bug Report"
+description: Report an issue or possible bug
+title: "\U0001F41B BUG:"
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ##  Quick Checklist
+        Thank you for taking the time to file a bug report! Please fill out this form as completely as possible.
+
+        ✅ I am using the **latest version of Neo**.
+        ✅ I am using a version of Node that supports ESM (`v14.15.0+`, or `v16.0.0+`)
+  - type: input
+    id: neo-version
+    attributes:
+      label: What version of `Neo` are you using?
+      placeholder: 0.0.0
+    validations:
+      required: true
+  - type: input
+    id: ssr-adapter
+    attributes:
+      label: Are you using an SSR adapter? If so, which one?
+      placeholder: None, or Netlify, Vercel, Cloudflare, etc.
+    validations:
+      required: true
+  - type: input
+    id: package-manager
+    attributes:
+      label: What package manager are you using?
+      placeholder: npm, yarn, pnpm
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: What operating system are you using?
+      placeholder: Mac, Windows, Linux
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: input
+    id: bug-reproduction
+    attributes:
+      label: Link to Minimal Reproducible Example
+      placeholder: 'https://stackblitz.com/abcd1234'
+    validations:
+      required: true
+  - type: checkboxes
+    id: will-pr
+    attributes:
+      label: Participation
+      options:
+        - label:  I am willing to submit a pull request for this issue.
+          required: false

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,13 @@
+[Link to updated components in Deploy Preview](UPDATEMEWITHALINK)
+
+Put the most important information here. The content that any reviewer should see and read first (after the PR title).
+
+**EXAMPLE IMAGE(S):**
+[PUT EXAMPLES HERE, such as an image of the new tests, or important use case added by this update]
+
+**EXAMPLE FUNCTIONALITY GIF:**
+[PUT EXAMPLE GIF HERE]
+
+**IMPORTANT NOTES:**
+- Put any secondary, but still important, notes here
+- May be bullets or a single sentence/paragraph


### PR DESCRIPTION
This adds two templates. A PR Template (example image below), and an Issues Template that includes a form.

On GitHub.com or a GUI (GitKraken for example), you will be presented with a dropdown with a PR template so that you 
![Screen Shot 2022-06-27 at 2 11 37 PM](https://user-images.githubusercontent.com/55896546/176036700-79cc1df5-9f7e-463e-a774-3dd05ec70657.png)

The PR Template I built from scratch and simply followed the [GitHub Docs example](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

The Issues Template I stole (mostly) [from Astro](https://github.com/withastro/astro/blob/main/.github/ISSUE_TEMPLATE/---01-bug-report.yml). It may not be formatted correctly, or it may need some additional config, but I'm not sure how to test it and I wanted to get _something_ up and into our repo. 