### PR TITLE
NEO-735: LeftNavigation consistency and ease of use improvements

### DIFF
--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -29,7 +29,7 @@ import { LeftNavProps, NavigationContextType } from "./LeftNavigationTypes";
 export const LeftNavigation: FunctionComponent<LeftNavProps> = ({
   children,
   currentUrl = "",
-  onSelected,
+  onNavigate,
   ...rest
 }) => {
   if (!rest["aria-label"]) {
@@ -46,11 +46,11 @@ export const LeftNavigation: FunctionComponent<LeftNavProps> = ({
     (id: string, url: string) => {
       setCurUrl(url);
 
-      if (onSelected) {
-        onSelected(id, url);
+      if (onNavigate) {
+        onNavigate(id, url);
       }
     },
-    [onSelected]
+    [onNavigate]
   );
 
   const navContext: NavigationContextType = {

--- a/src/components/LeftNavigation/LeftNavigationTypes.tsx
+++ b/src/components/LeftNavigation/LeftNavigationTypes.tsx
@@ -22,7 +22,7 @@ export interface NavCategoryProps
 export interface LeftNavProps extends React.BaseHTMLAttributes<HTMLElement> {
   "aria-label": string;
   currentUrl?: string;
-  onSelected?: (id: string, url: string) => void;
+  onNavigate?: (id: string, url: string) => void;
   children?:
     | ReactElement<NavCategoryProps | TopLinkItemProps>
     | ReactElement<NavCategoryProps | TopLinkItemProps>[];

--- a/src/components/LeftNavigation/LinkItem/LinkItem.stories.tsx
+++ b/src/components/LeftNavigation/LinkItem/LinkItem.stories.tsx
@@ -27,7 +27,7 @@ export const LinkItems = () => (
   <LeftNavigation
     aria-label="Main Navigation"
     currentUrl=""
-    onSelected={handleClick}
+    onNavigate={handleClick}
   >
     <NavCategory label="Main Category">
       <LinkItem

--- a/src/components/LeftNavigation/LinkItem/LinkItem.test.jsx
+++ b/src/components/LeftNavigation/LinkItem/LinkItem.test.jsx
@@ -5,7 +5,7 @@ import { axe } from "jest-axe";
 import { LinkItem } from "./LinkItem";
 import * as LinkItemStories from "./LinkItem.stories";
 
-const { LinkItems, handleClick } = composeStories(LinkItemStories);
+const { LinkItems } = composeStories(LinkItemStories);
 
 describe("LinkItem", () => {
   const linkItemText = "example link item";

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from "@storybook/react/types-7-0";
-import { MouseEvent } from "react";
 import { TopLinkItem, TopLinkItemProps } from "./TopLinkItem";
 import { LeftNavigation } from "../LeftNavigation";
 
@@ -7,37 +6,28 @@ export default {
   title: "Components/Left Navigation/Top Link Item",
   component: TopLinkItem,
 } as Meta<TopLinkItemProps>;
-const handleClick = (e: MouseEvent) => {
-  e.preventDefault();
-  alert(`clicked on the item: ${e.currentTarget.textContent}`);
+const handleClick = (id: string, url: string) => {
+  alert(`clicked on the item with id: ${id}, url: ${url}`);
 };
 export const Default = () => (
-  <LeftNavigation aria-label="Main Navigation" currentUrl="">
-    <TopLinkItem label="Normal Link" onClick={handleClick} href="#" />
-    <TopLinkItem active label="Active Link" onClick={handleClick} href="#" />
-    <TopLinkItem
-      label="Normal Link with Icon"
-      icon="address-book"
-      onClick={handleClick}
-      href="#"
-    />
+  <LeftNavigation
+    aria-label="Main Navigation"
+    onSelected={handleClick}
+    currentUrl=""
+  >
+    <TopLinkItem label="Normal Link" href="#" />
+    <TopLinkItem active label="Active Link" href="#" />
+    <TopLinkItem label="Normal Link with Icon" icon="address-book" href="#" />
     <TopLinkItem
       active
       label="Active Link with Icon"
       icon="address-book"
-      onClick={handleClick}
       href="#"
     />
-    <TopLinkItem
-      label="Disabled Link"
-      onClick={handleClick}
-      disabled
-      href="#"
-    />
+    <TopLinkItem label="Disabled Link" disabled href="#" />
     <TopLinkItem
       label="Disabled Link with Icon"
       icon="address-book"
-      onClick={handleClick}
       disabled
       href="#"
     />

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.stories.tsx
@@ -12,7 +12,7 @@ const handleClick = (id: string, url: string) => {
 export const Default = () => (
   <LeftNavigation
     aria-label="Main Navigation"
-    onSelected={handleClick}
+    onNavigate={handleClick}
     currentUrl=""
   >
     <TopLinkItem label="Normal Link" href="#" />

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.test.jsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.test.jsx
@@ -58,7 +58,7 @@ describe("TopLinkItem", () => {
     const { getByText } = render(
       <LeftNavigation
         aria-label="Main Navigation"
-        onSelected={mockedFunction}
+        onNavigate={mockedFunction}
         currentUrl=""
       >
         <TopLinkItem label={TopLinkItemLabel} />

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.test.jsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.test.jsx
@@ -2,6 +2,7 @@ import { composeStories } from "@storybook/testing-react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { TopLinkItem } from "./TopLinkItem";
+import { LeftNavigation } from "../LeftNavigation";
 import * as TopLinkItemStories from "./TopLinkItem.stories";
 
 const { Default } = composeStories(TopLinkItemStories);
@@ -55,7 +56,13 @@ describe("TopLinkItem", () => {
   it("should simulate onclick function when not disabled", () => {
     const mockedFunction = jest.fn();
     const { getByText } = render(
-      <TopLinkItem onClick={mockedFunction} label={TopLinkItemLabel} />
+      <LeftNavigation
+        aria-label="Main Navigation"
+        onSelected={mockedFunction}
+        currentUrl=""
+      >
+        <TopLinkItem label={TopLinkItemLabel} />
+      </LeftNavigation>
     );
     const linkElement = getByText(TopLinkItemLabel);
     fireEvent.click(linkElement);

--- a/src/components/LeftNavigation/TopLinkItem/TopLinkItem.tsx
+++ b/src/components/LeftNavigation/TopLinkItem/TopLinkItem.tsx
@@ -1,14 +1,16 @@
 import clsx from "clsx";
 import { Button } from "components/Button";
-import { IconNamesType } from "utils";
+import { MouseEventHandler, useContext } from "react";
+import { genId, IconNamesType } from "utils";
+import { NavigationContext } from "../NavigationContext";
 import "./TopLinkItem_shim.css";
 export interface TopLinkItemProps {
   active?: boolean;
   label: string;
-  href?: string;
+  href: string;
   icon?: IconNamesType;
+  id?: string;
   disabled?: boolean;
-  onClick?: (e: React.MouseEvent<Element, MouseEvent>) => void;
 }
 
 export const TopLinkItem = ({
@@ -16,9 +18,16 @@ export const TopLinkItem = ({
   label,
   href,
   icon,
+  id = genId(),
   disabled,
-  onClick,
 }: TopLinkItemProps) => {
+  const ctx = useContext(NavigationContext);
+
+  const onClick: MouseEventHandler = (e) => {
+    e.preventDefault();
+    ctx?.onSelectedLink && ctx.onSelectedLink(id, href);
+  };
+
   return (
     <li
       className={clsx(


### PR DESCRIPTION
This fixes no bugs but it's a small refactor to make life easier for the developer:

The TopLinkItem component handled mouse clicks differently than the LinkItem subComponent. This change makes it consistent and also greatly simplifies life for the developer because it leverages the top Level "onNavigate" handler.

Also renamed onSelected to onNavigate to reflect the true use for this prop callback.