### PR TITLE
NEO-1059 Left Navigation / NavCategory state fixes

### DIFF
--- a/src/components/LeftNavigation/NavCategory/NavCategory.tsx
+++ b/src/components/LeftNavigation/NavCategory/NavCategory.tsx
@@ -66,6 +66,7 @@ export const NavCategory = ({
   const [isExpanded, setIsExpanded] = useState(expanded);
   const [navItemClass, setNavItemClass] = useState(LEFTNAV_CATEGORY_STYLE);
   const [iconClass, setIconClass] = useState("");
+  const [childIsActive, setChildIsActive] = useState(false);
 
   const ref = useRef(null);
   const [tabIndex, isActive, handleKeyIndex, handleClick] = useRovingTabIndex(
@@ -77,14 +78,25 @@ export const NavCategory = ({
   const ctx = useContext(NavigationContext);
 
   useEffect(() => {
-    const itemStyle = getNavBarClassNames(isExpanded, isActive, disabled);
+    const active = isActive || childIsActive;
+    const itemStyle = getNavBarClassNames(isExpanded, active, disabled);
     setNavItemClass(itemStyle);
-  }, [isExpanded, isActive, disabled]);
+  }, [isExpanded, isActive, disabled, childIsActive]);
 
   useEffect(() => {
     const iconStyles = getIconClass(icon);
     setIconClass(iconStyles);
   }, [icon]);
+
+  useEffect(() => {
+    console.log("currentUrl = ", ctx.currentUrl);
+    let hasActiveLinks = false;
+    Children.map(children, (child) => {
+      hasActiveLinks = hasActiveLinks || child.props.href === ctx.currentUrl;
+    });
+    console.log("NavCategory: ", label, "hasActiveLinks: ", hasActiveLinks);
+    setChildIsActive(hasActiveLinks);
+  }, [ctx.currentUrl]);
 
   const handleOnClick: MouseEventHandler = (event: MouseEvent) => {
     event.stopPropagation();
@@ -132,7 +144,7 @@ export const NavCategory = ({
         parentHasIcon: parentHasIcon,
       });
     });
-  }, [isExpanded, disabled, ctx]);
+  }, [isExpanded, disabled, ctx.currentUrl]);
 
   return (
     <li id={internalId} className={navItemClass}>

--- a/src/components/LeftNavigation/NavCategory/NavCategory.tsx
+++ b/src/components/LeftNavigation/NavCategory/NavCategory.tsx
@@ -78,7 +78,7 @@ export const NavCategory = ({
   const ctx = useContext(NavigationContext);
 
   useEffect(() => {
-    const active = isActive || childIsActive;
+    const active = childIsActive;
     const itemStyle = getNavBarClassNames(isExpanded, active, disabled);
     setNavItemClass(itemStyle);
   }, [isExpanded, isActive, disabled, childIsActive]);
@@ -89,12 +89,10 @@ export const NavCategory = ({
   }, [icon]);
 
   useEffect(() => {
-    console.log("currentUrl = ", ctx.currentUrl);
     let hasActiveLinks = false;
     Children.map(children, (child) => {
       hasActiveLinks = hasActiveLinks || child.props.href === ctx.currentUrl;
     });
-    console.log("NavCategory: ", label, "hasActiveLinks: ", hasActiveLinks);
     setChildIsActive(hasActiveLinks);
   }, [ctx.currentUrl]);
 


### PR DESCRIPTION
UX improvement / bug fix: The NavCategory now automatically changes its Active state/style if one of its children is the active link.
See gif to see it in action.

![2022-07-25 11 55 45](https://user-images.githubusercontent.com/3535271/180854078-6955d6db-dd89-41b9-9bf1-6b3ff02e25b7.gif)

NOTE: There seems to be a CSS regression in the hover styles for some elements. This needs to be fixed in the Neo CSS library and it's not related to this checkin.