### PR TITLE
update renovate config to properly tag team

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,14 @@
     "group:allNonMajor", // batch non-majors into one PR
     ":semanticCommits", // nicer commit messages
   ],
-  assignees: ["dux-devs"],
+  assignees: [
+    "@avaya-dux/dux-devs",
+    "enrique-prado",
+    "joe-s-avaya",
+    "mrazian85",
+    "thota499",
+    "yangAtSpoken",
+  ],
   labels: ["dependencies"],
   pin: false,
   rangeStrategy: "bump",


### PR DESCRIPTION
I'm not sure if I can use the "team" name, so I'm using it _and_ everyone on the team. Will remove the specific people if the team name tag works.